### PR TITLE
fix: restore Python 3.12/3.13 compatibility so `import raja` works on the declared minimum

### DIFF
--- a/lambda_handlers/rale_authorizer/handler.py
+++ b/lambda_handlers/rale_authorizer/handler.py
@@ -236,7 +236,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         allowed = service.has_package_grant(project_id=project_id, quilt_uri=quilt_uri)
     except DataZoneError:
         return _response(503, {"error": "authorization service unavailable"})
-    except ClientError, BotoCoreError:
+    except (ClientError, BotoCoreError):
         return _response(503, {"error": "authorization service unavailable"})
 
     if not allowed:
@@ -248,7 +248,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         if jwt_secret_version:
             secret_kwargs["VersionId"] = jwt_secret_version
         jwt_secret = secrets.get_secret_value(**secret_kwargs)["SecretString"]
-    except ClientError, BotoCoreError, KeyError:
+    except (ClientError, BotoCoreError, KeyError):
         return _response(503, {"error": "failed to load jwt secret"})
 
     token_ttl = int(os.environ.get("TOKEN_TTL", "3600"))

--- a/lambda_handlers/rale_router/handler.py
+++ b/lambda_handlers/rale_router/handler.py
@@ -133,7 +133,7 @@ def _proxy_get_or_head(
         )
     except s3_client.exceptions.NoSuchKey:
         return _response(404, {"error": "object not found"})
-    except ClientError, BotoCoreError:
+    except (ClientError, BotoCoreError):
         return _response(502, {"error": "failed to fetch object from S3"})
 
 
@@ -161,14 +161,14 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         if jwt_secret_version:
             secret_kwargs["VersionId"] = jwt_secret_version
         jwt_secret = secrets.get_secret_value(**secret_kwargs)["SecretString"]
-    except ClientError, BotoCoreError, KeyError:
+    except (ClientError, BotoCoreError, KeyError):
         return _response(503, {"error": "failed to load jwt secret"})
 
     try:
         claims = validate_taj_token(taj, jwt_secret)
     except TokenExpiredError:
         return _response(401, {"error": "expired TAJ"})
-    except TokenInvalidError, TokenValidationError:
+    except (TokenInvalidError, TokenValidationError):
         return _response(401, {"error": "invalid TAJ"})
 
     # For un-pinned USLs the hash comes from the TAJ; for pinned USLs validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ build-backend = "uv_build"
 rale = "raja.cli:main"
 
 [tool.ruff]
-target-version = "py314"
+# target-version is inferred from project.requires-python, so the formatter and
+# linter never emit syntax that is newer than the interpreters we support.
 line-length = 100
 extend-exclude = ["infra/cdk.out", "infra/cdk.out*"]
 

--- a/src/raja/datazone/service.py
+++ b/src/raja/datazone/service.py
@@ -231,7 +231,7 @@ class DataZoneService:
                 domainIdentifier=self._config.domain_id,
                 identifier=asset_id,
             )
-        except ClientError, BotoCoreError:
+        except (ClientError, BotoCoreError):
             return ""
         if not isinstance(response, dict):
             return ""
@@ -263,7 +263,7 @@ class DataZoneService:
             )
             arn: str | None = resp.get("details", {}).get("iam", {}).get("arn")
             return arn
-        except ClientError, BotoCoreError:
+        except (ClientError, BotoCoreError):
             return None
 
     def _get_user_id_for_principal(self, principal: str) -> str | None:
@@ -276,7 +276,7 @@ class DataZoneService:
             )
             user_id: str | None = resp.get("id")
             return user_id
-        except ClientError, BotoCoreError:
+        except (ClientError, BotoCoreError):
             return None
 
     def _resolve_membership_user_identifier(self, user_identifier: str) -> str:

--- a/src/raja/scope.py
+++ b/src/raja/scope.py
@@ -74,7 +74,7 @@ def _normalize_scopes(scopes: Iterable[Scope | str]) -> set[str]:
                 normalized.add(format_scope(scope.resource_type, scope.resource_id, scope.action))
             else:
                 normalized.add(format_scope(**parse_scope(scope).model_dump()))
-        except ScopeParseError, ScopeValidationError:
+        except (ScopeParseError, ScopeValidationError):
             # Re-raise our custom exceptions
             raise
         except Exception as exc:

--- a/tests/unit/test_python_floor.py
+++ b/tests/unit/test_python_floor.py
@@ -1,0 +1,60 @@
+"""Guard the minimum Python version declared in pyproject.toml.
+
+The published package and the Lambda bundles must parse on the oldest
+interpreter ``requires-python`` allows. The CI matrix cannot be relied on for
+this: ``uv sync`` resolves the interpreter from ``.python-version``, so every
+matrix job runs the same version regardless of ``actions/setup-python``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_ROOTS = (REPO_ROOT / "src", REPO_ROOT / "lambda_handlers")
+
+
+def minimum_python() -> tuple[int, int]:
+    """Return the lowest (major, minor) accepted by ``requires-python``."""
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    requires_python = pyproject["project"]["requires-python"]
+    match = re.search(r">=\s*(\d+)\.(\d+)", requires_python)
+    if not match:
+        pytest.fail(f"cannot read a minimum version from requires-python: {requires_python}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def source_files() -> list[Path]:
+    return sorted(path for root in SOURCE_ROOTS for path in root.rglob("*.py"))
+
+
+def test_sources_parse_on_minimum_python() -> None:
+    floor = minimum_python()
+    failures: list[str] = []
+
+    for path in source_files():
+        try:
+            ast.parse(path.read_text(), filename=str(path), feature_version=floor)
+        except SyntaxError as exc:
+            relative = path.relative_to(REPO_ROOT)
+            failures.append(f"{relative}:{exc.lineno}: {exc.msg}")
+
+    assert not failures, "syntax not supported on Python {}.{}:\n{}".format(
+        floor[0], floor[1], "\n".join(failures)
+    )
+
+
+def test_feature_version_rejects_newer_syntax() -> None:
+    """Fail loudly if ``feature_version`` stops gating syntax we rely on it for."""
+    floor = minimum_python()
+    if floor >= (3, 14):
+        pytest.skip("minimum Python already allows unparenthesized except expressions")
+
+    source = "try:\n    pass\nexcept ValueError, TypeError:\n    pass\n"
+    with pytest.raises(SyntaxError):
+        ast.parse(source, feature_version=floor)


### PR DESCRIPTION
This PR proposes restoring Python 3.12/3.13 compatibility, so that `import raja` works on the interpreters `requires-python` declares. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/342. You can sign in with your GitHub ID to claim ownership of the project.

## What is broken

`pyproject.toml` declares `requires-python = ">=3.12"`, and the CI workflow's unit-test matrix lists `python-version: ['3.12', '3.13']`. On both of those interpreters the package cannot be imported at all: eight `except` clauses use the unparenthesized multi-exception form (`except ClientError, BotoCoreError:`), which is PEP 758 syntax and only parses on Python 3.14. Four of them are in code you ship — `src/raja/scope.py`, `src/raja/datazone/service.py` — and the rest are in `lambda_handlers/rale_authorizer/handler.py` and `lambda_handlers/rale_router/handler.py`. Because `src/raja/__init__.py` re-exports `parse_scope`/`is_subset` through `enforcer.py`, the very first line of any user's script fails.

Reproduced on `main` at `e7aa23b`:

```console
$ uv build --wheel
Successfully built dist/raja-1.3.2-py3-none-any.whl
$ uv venv --python 3.12 /tmp/raja312 && uv pip install --python /tmp/raja312/bin/python dist/raja-1.3.2-py3-none-any.whl
$ /tmp/raja312/bin/python -c "import raja"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/raja312/lib/python3.12/site-packages/raja/__init__.py", line 1, in <module>
    from .enforcer import (
  File "/tmp/raja312/lib/python3.12/site-packages/raja/enforcer.py", line 17, in <module>
    from .scope import format_scope, parse_scope
  File "/tmp/raja312/lib/python3.12/site-packages/raja/scope.py", line 77
    except ScopeParseError, ScopeValidationError:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesized
```

The same thing happens to the test suite: `uv run --python 3.12 --extra test python -m pytest tests/unit/` on `main` collects nothing and dies at the import above.

Two things hide this today. The CI matrix does not actually vary the interpreter — `actions/setup-python` installs 3.12/3.13, but `uv sync` then builds the environment from `.python-version`, which has been `3.14` since #58, so all four matrix jobs run 3.14 and pass. And `[tool.ruff] target-version = "py314"`, set while `requires-python` is `>=3.12`, means `ruff format` actively rewrites the parenthesized form back to the 3.14-only one — running `./poe check` on a corrected file undoes the correction.

## The change

Parenthesizing the exception tuples is semantically identical on 3.14 and restores parsing on 3.12/3.13, so no runtime behaviour changes on any supported interpreter. I also dropped the explicit `target-version` from `[tool.ruff]`; ruff then infers it from `project.requires-python`, so the formatter can never again emit syntax newer than what you support, and the setting follows automatically if you raise the floor later. `tests/unit/test_python_floor.py` reads the minimum version out of `pyproject.toml` and parses every module under `src/` and `lambda_handlers/` at that version, so the floor is enforced regardless of which interpreter the suite happens to run on.

Verified before and after, from a clean checkout:

- The new test fails on the unfixed tree, naming all four modules, and passes after — `pytest tests/unit/test_python_floor.py`.
- On Python 3.12, `uv run --python 3.12 --extra test python -m pytest tests/unit/` goes from a collection failure to `266 passed`.
- On 3.14 (your `.python-version`), `pytest tests/unit/` goes from `264 passed` to `266 passed` — the two additions, no other movement.
- `ruff check .` reports the same four pre-existing findings under `scripts/` as before, and `ruff format --check .` names exactly the same eight files as before this change (all under `scripts/`, none touched here). `mypy src/raja` remains clean.
- Exercised the changed re-raise path on 3.12 against the rebuilt wheel: `is_subset(scope, ["not-a-scope"])` still raises `ScopeParseError`, and exact/miss subset checks still return `True`/`False`.

Two related things I deliberately left alone, so this stays one change. `[tool.mypy] python_version = "3.14"` is the same mismatch as the ruff setting; I checked that `python_version = "3.12"` is clean today, and I am happy to include that line if you want it. And making the CI matrix real — passing the action's `python-version` input through to `uv sync --python` in `.github/actions/setup-raja` — would catch this class in CI, but two dependency PRs are already open against that file, so I left it to you.

## How this was managed

I imported your issues and pull requests into an agile board — 79 stories — and tracked this work on it as [Restore Python 3.12/3.13 compatibility](https://eastagiletracker.com/projects/342/stories/215983), on the board at https://eastagiletracker.com/projects/342.

![board](https://raw.githubusercontent.com/eastagiletracker/raja/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores compatibility with the declared Python 3.12 minimum and adds a regression test for unsupported syntax.
- Parenthesizes multi-exception handlers in the packaged library and Lambda handlers.
- Lets Ruff infer its target from `project.requires-python`.
- Parses shipped library and Lambda sources against the declared Python floor during unit tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the compatibility fixes preserving existing exception-handling semantics and the new test covering all shipped Python sources.

The parenthesized handlers are valid across all declared interpreters, current Ruff invocations correctly infer Python 3.12 from the project metadata, and no concrete blocking or non-blocking defect remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/raja/scope.py | Parenthesizes the exception tuple so the module parses on Python 3.12 and 3.13 without changing exception handling. |
| src/raja/datazone/service.py | Converts three multi-exception handlers to syntax supported by the declared Python floor. |
| lambda_handlers/rale_authorizer/handler.py | Makes authorization-service and secret-loading exception handlers parse on supported Lambda interpreters. |
| lambda_handlers/rale_router/handler.py | Makes S3, secret-loading, and token-validation exception handlers compatible with Python 3.12 and 3.13. |
| pyproject.toml | Removes the conflicting Python 3.14 Ruff target so the locked Ruff version infers Python 3.12 from project metadata. |
| tests/unit/test_python_floor.py | Adds coverage that parses all shipped package and Lambda modules using the declared minimum grammar and validates the relevant feature-version gate. |

<sub>Reviews (1): Last reviewed commit: ["fix: restore Python 3.12/3.13 compatibil..."](https://github.com/quiltdata/raja/commit/633dba0619a39eac5a36c4f070022db911c4ec1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52929180)</sub>

<!-- /greptile_comment -->